### PR TITLE
Improve the pagination of `Entry` resources (in the frontend)

### DIFF
--- a/backend/src/utilities.ts
+++ b/backend/src/utilities.ts
@@ -11,7 +11,7 @@ export const buildLinkWithPaginationParams = (
   return changedUrl.pathname + changedUrl.search;
 };
 
-const PER_PAGE_DEFAULT: number = 3;
+const PER_PAGE_DEFAULT: number = 10;
 const PER_PAGE_MAX: number = 100;
 
 const PAGE_DEFAULT: number = 1;

--- a/backend/src/utilities.ts
+++ b/backend/src/utilities.ts
@@ -11,7 +11,7 @@ export const buildLinkWithPaginationParams = (
   return changedUrl.pathname + changedUrl.search;
 };
 
-const PER_PAGE_DEFAULT: number = 10;
+const PER_PAGE_DEFAULT: number = 3;
 const PER_PAGE_MAX: number = 100;
 
 const PAGE_DEFAULT: number = 1;

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -90,91 +90,46 @@ test("initial render (i.e. before/without any user interaction)", async () => {
   expect(element).toBeInTheDocument();
 });
 
-test("render after the user has signed in", async () => {
-  // Arrange.
-  requestInterceptionLayer.use(
-    rest.get("/api/user-profile", requestHandlers.mockFetchUserProfile)
-  );
-
-  const realStore = createStore(rootReducer, initState, enhancer);
-
-  // Act.
-  render(
-    <Provider store={realStore}>
-      <Router history={history}>
-        <App />
-      </Router>
-    </Provider>
-  );
-
-  // Assert.
-  let element: HTMLElement;
-
-  element = await screen.findByText("Hello, mocked-John Doe!");
-  expect(element).toBeInTheDocument();
-
-  element = screen.getByText("Sign Out");
-  expect(element).toBeInTheDocument();
-  element = screen.getByText("JournalEntries");
-  expect(element).toBeInTheDocument();
-  element = screen.getByText("Home");
-  expect(element).toBeInTheDocument();
-});
-
-test("after the user has signed in, the user clicks on 'Sign Out'", async () => {
-  // Arrange.
-  requestInterceptionLayer.use(
-    rest.get("/api/user-profile", requestHandlers.mockFetchUserProfile)
-  );
-
-  const realStore = createStore(rootReducer, initState, enhancer);
-
-  render(
-    <Provider store={realStore}>
-      <Router history={history}>
-        <App />
-      </Router>
-    </Provider>
-  );
-
-  // Act.
-  const signOutAnchor: HTMLElement = await screen.findByText("Sign Out");
-  fireEvent.click(signOutAnchor);
-
-  // Assert.
-  let element: HTMLElement;
-
-  element = await screen.findByText("SIGN-OUT SUCCESSFUL");
-  expect(element).toBeInTheDocument();
-
-  element = screen.getByText("Welcome to JournalKeeper!");
-  expect(element).toBeInTheDocument();
-
-  element = screen.getByText("Home");
-  expect(element).toBeInTheDocument();
-  element = screen.getByText("Sign In");
-  expect(element).toBeInTheDocument();
-  element = screen.getByText("Sign Up");
-  expect(element).toBeInTheDocument();
-});
-
-test(
-  "after the user has signed in, the user clicks on 'Sign Out'" +
-    " - that should update the `localStorage` correctly",
-  async () => {
+describe("workflows that involve little more than signing in", () => {
+  test("render after the user has signed in", async () => {
     // Arrange.
     requestInterceptionLayer.use(
       rest.get("/api/user-profile", requestHandlers.mockFetchUserProfile)
     );
 
-    localStorage.setItem(JOURNAL_APP_TOKEN, "a-jws-token-issued-by-the-backend");
-    // Strictly speaking, the setup logic for this test case renders
-    // the next two statements unnecessary-to-have,
-    // but including them is of some instructive value.
-    initState.auth.token = localStorage.getItem(JOURNAL_APP_TOKEN);
-    initState.auth.hasValidToken = true;
+    const realStore = createStore(rootReducer, initState, enhancer);
+
+    // Act.
+    render(
+      <Provider store={realStore}>
+        <Router history={history}>
+          <App />
+        </Router>
+      </Provider>
+    );
+
+    // Assert.
+    let element: HTMLElement;
+
+    element = await screen.findByText("Hello, mocked-John Doe!");
+    expect(element).toBeInTheDocument();
+
+    element = screen.getByText("Sign Out");
+    expect(element).toBeInTheDocument();
+    element = screen.getByText("JournalEntries");
+    expect(element).toBeInTheDocument();
+    element = screen.getByText("Home");
+    expect(element).toBeInTheDocument();
+  });
+
+  test("after the user has signed in, the user clicks on 'Sign Out'", async () => {
+    // Arrange.
+    requestInterceptionLayer.use(
+      rest.get("/api/user-profile", requestHandlers.mockFetchUserProfile)
+    );
 
     const realStore = createStore(rootReducer, initState, enhancer);
+
     render(
       <Provider store={realStore}>
         <Router history={history}>
@@ -188,39 +143,12 @@ test(
     fireEvent.click(signOutAnchor);
 
     // Assert.
-    expect(localStorage.getItem(JOURNAL_APP_TOKEN)).toEqual(null);
-  }
-);
-
-test(
-  "if a user hasn't signed in" +
-    " but manually saves a token in their web-browser's `localStorage`," +
-    " the frontend application should display only the following navigation links:" +
-    " 'Home', 'Sign In', 'Sign Up'",
-  async () => {
-    // Arrange.
-
-    // Strictly speaking, the setup logic for this test case renders
-    // the next two statements unnecessary-to-have,
-    // but including them is of some instructive value.
-    localStorage.setItem(JOURNAL_APP_TOKEN, "a-jws-token-NOT-issued-by-the-backend");
-    initState.auth.token = localStorage.getItem(JOURNAL_APP_TOKEN);
-
-    const realStore = createStore(rootReducer, initState, enhancer);
-
-    // Act.
-    render(
-      <Provider store={realStore}>
-        <Router history={history}>
-          <App />
-        </Router>
-      </Provider>
-    );
-
-    // Assert.
     let element: HTMLElement;
 
-    element = await screen.findByText("TO CONTINUE, PLEASE SIGN IN");
+    element = await screen.findByText("SIGN-OUT SUCCESSFUL");
+    expect(element).toBeInTheDocument();
+
+    element = screen.getByText("Welcome to JournalKeeper!");
     expect(element).toBeInTheDocument();
 
     element = screen.getByText("Home");
@@ -229,99 +157,311 @@ test(
     expect(element).toBeInTheDocument();
     element = screen.getByText("Sign Up");
     expect(element).toBeInTheDocument();
-  }
-);
+  });
 
-xtest(
-  "if a user signs in" +
-    " and goes on to manually change the URL in her browser's address bar" +
-    " to /journal-entries ," +
-    " the frontend application should redirect to / (but keep the user signed in)",
-  async () => {
-    // Arrange.
-    requestInterceptionLayer.use(
-      rest.get("/api/user-profile", requestHandlers.mockFetchUserProfile),
+  test(
+    "after the user has signed in, the user clicks on 'Sign Out'" +
+      " - that should update the `localStorage` correctly",
+    async () => {
+      // Arrange.
+      requestInterceptionLayer.use(
+        rest.get("/api/user-profile", requestHandlers.mockFetchUserProfile)
+      );
 
-      rest.get("/api/entries", requestHandlers.mockFetchEntries),
-      rest.get("/api/user-profile", requestHandlers.mockFetchUserProfile)
-    );
+      localStorage.setItem(JOURNAL_APP_TOKEN, "a-jws-token-issued-by-the-backend");
+      // Strictly speaking, the setup logic for this test case renders
+      // the next two statements unnecessary-to-have,
+      // but including them is of some instructive value.
+      initState.auth.token = localStorage.getItem(JOURNAL_APP_TOKEN);
+      initState.auth.hasValidToken = true;
 
-    const realStore = createStore(rootReducer, initState, enhancer);
+      const realStore = createStore(rootReducer, initState, enhancer);
+      render(
+        <Provider store={realStore}>
+          <Router history={history}>
+            <App />
+          </Router>
+        </Provider>
+      );
 
-    // Act:
+      // Act.
+      const signOutAnchor: HTMLElement = await screen.findByText("Sign Out");
+      fireEvent.click(signOutAnchor);
 
-    // - navigate to the root URL, and mount the application's entire React tree
-    history.push("/");
+      // Assert.
+      expect(localStorage.getItem(JOURNAL_APP_TOKEN)).toEqual(null);
+    }
+  );
 
-    const { getByText: getByTextFromRootURL } = render(
-      <Provider store={realStore}>
-        <Router history={history}>
-          <App />
-        </Router>
-      </Provider>
-    );
+  test(
+    "if a user hasn't signed in" +
+      " but manually saves a token in their web-browser's `localStorage`," +
+      " the frontend application should display only the following navigation links:" +
+      " 'Home', 'Sign In', 'Sign Up'",
+    async () => {
+      // Arrange.
 
-    let element: HTMLElement;
+      // Strictly speaking, the setup logic for this test case renders
+      // the next two statements unnecessary-to-have,
+      // but including them is of some instructive value.
+      localStorage.setItem(JOURNAL_APP_TOKEN, "a-jws-token-NOT-issued-by-the-backend");
+      initState.auth.token = localStorage.getItem(JOURNAL_APP_TOKEN);
 
-    element = await screen.findByText("Hello, mocked-John Doe!");
-    expect(element).toBeInTheDocument();
+      const realStore = createStore(rootReducer, initState, enhancer);
 
-    // - unamount React trees that were mounted with render
-    cleanup();
+      // Act.
+      render(
+        <Provider store={realStore}>
+          <Router history={history}>
+            <App />
+          </Router>
+        </Provider>
+      );
 
-    // - navigate to the /journal-entries URL,
-    //   and mount the application's entire React tree
-    console.log("[the test case is]");
-    console.log("navigating to the /journal-entries URL");
-    console.log("and mounting the application's entire React tree");
+      // Assert.
+      let element: HTMLElement;
 
-    history.push("/journal-entries");
+      element = await screen.findByText("TO CONTINUE, PLEASE SIGN IN");
+      expect(element).toBeInTheDocument();
 
-    render(
-      <Provider store={realStore}>
-        <Router history={history}>
-          <App />
-        </Router>
-      </Provider>
-    );
+      element = screen.getByText("Home");
+      expect(element).toBeInTheDocument();
+      element = screen.getByText("Sign In");
+      expect(element).toBeInTheDocument();
+      element = screen.getByText("Sign Up");
+      expect(element).toBeInTheDocument();
+    }
+  );
 
-    // Assert.
-    await waitFor(() => {
-      expect(history.location.pathname).toEqual("/");
-    });
+  xtest(
+    "if a user signs in" +
+      " and goes on to manually change the URL in her browser's address bar" +
+      " to /journal-entries ," +
+      " the frontend application should redirect to / (but keep the user signed in)",
+    async () => {
+      // Arrange.
+      requestInterceptionLayer.use(
+        rest.get("/api/user-profile", requestHandlers.mockFetchUserProfile),
 
-    element = screen.getByText("Hello, mocked-John Doe!");
-    expect(element).toBeInTheDocument();
-  }
-);
+        rest.get("/api/entries", requestHandlers.mockFetchEntries),
+        rest.get("/api/user-profile", requestHandlers.mockFetchUserProfile)
+      );
 
-test(
-  "if a user hasn't signed in" +
-    " but manually changes the URL in her browser's address bar" +
-    " to /journal-entries ," +
-    " the frontend application should redirect the user to /sign-in",
-  async () => {
-    // Arrange.
-    const realStore = createStore(rootReducer, initState, enhancer);
+      const realStore = createStore(rootReducer, initState, enhancer);
 
-    // Act.
-    history.push("/journal-entries");
+      // Act:
 
-    render(
-      <Provider store={realStore}>
-        <Router history={history}>
-          <App />
-        </Router>
-      </Provider>
-    );
+      // - navigate to the root URL, and mount the application's entire React tree
+      history.push("/");
 
-    // Assert.
-    const element: HTMLElement = await screen.findByText("TO CONTINUE, PLEASE SIGN IN");
-    expect(element).toBeInTheDocument();
+      const { getByText: getByTextFromRootURL } = render(
+        <Provider store={realStore}>
+          <Router history={history}>
+            <App />
+          </Router>
+        </Provider>
+      );
 
-    expect(history.location.pathname).toEqual("/sign-in");
+      let element: HTMLElement;
 
-    const elements: HTMLElement[] = screen.queryAllByText("Review JournalEntries!");
-    expect(elements.length).toEqual(0);
-  }
-);
+      element = await screen.findByText("Hello, mocked-John Doe!");
+      expect(element).toBeInTheDocument();
+
+      // - unamount React trees that were mounted with render
+      cleanup();
+
+      // - navigate to the /journal-entries URL,
+      //   and mount the application's entire React tree
+      console.log("[the test case is]");
+      console.log("navigating to the /journal-entries URL");
+      console.log("and mounting the application's entire React tree");
+
+      history.push("/journal-entries");
+
+      render(
+        <Provider store={realStore}>
+          <Router history={history}>
+            <App />
+          </Router>
+        </Provider>
+      );
+
+      // Assert.
+      await waitFor(() => {
+        expect(history.location.pathname).toEqual("/");
+      });
+
+      element = screen.getByText("Hello, mocked-John Doe!");
+      expect(element).toBeInTheDocument();
+    }
+  );
+
+  test(
+    "if a user hasn't signed in" +
+      " but manually changes the URL in her browser's address bar" +
+      " to /journal-entries ," +
+      " the frontend application should redirect the user to /sign-in",
+    async () => {
+      // Arrange.
+      const realStore = createStore(rootReducer, initState, enhancer);
+
+      // Act.
+      history.push("/journal-entries");
+
+      render(
+        <Provider store={realStore}>
+          <Router history={history}>
+            <App />
+          </Router>
+        </Provider>
+      );
+
+      // Assert.
+      const element: HTMLElement = await screen.findByText(
+        "TO CONTINUE, PLEASE SIGN IN"
+      );
+      expect(element).toBeInTheDocument();
+
+      expect(history.location.pathname).toEqual("/sign-in");
+
+      const elements: HTMLElement[] = screen.queryAllByText("Review JournalEntries!");
+      expect(elements.length).toEqual(0);
+    }
+  );
+});
+
+describe("workflows that involve signing in and deleting an Entry", () => {
+  beforeEach(() => {
+    initState = {
+      ...INITIAL_STATE,
+    };
+  });
+
+  test(
+    "the user clicks on the 'Yes' button," +
+      " and the backend is _mocked_ to respond that" +
+      " the DELETE request was accepted as valid and processed",
+    async () => {
+      // Arrange.
+      const realStore = createStore(rootReducer, initState, enhancer);
+
+      requestInterceptionLayer.use(
+        // rest.post("/api/tokens", requestHandlers.mockIssueJWSToken),
+        rest.get("/api/user-profile", requestHandlers.mockFetchUserProfile),
+
+        rest.get("/api/entries", requestHandlers.mockFetchEntries),
+
+        rest.delete("/api/entries/:id", requestHandlers.mockDeleteEntry),
+        rest.get("/api/entries", requestHandlers.mockFetchEntries),
+
+        rest.get("/api/entries", requestHandlers.mockFetchEntries)
+      );
+
+      render(
+        <Provider store={realStore}>
+          <Router history={history}>
+            <App />
+          </Router>
+        </Provider>
+      );
+
+      // const alert: HTMLElement = await screen.findByText("TO CONTINUE, PLEASE SIGN IN");
+      // expect(alert).toBeInTheDocument();
+
+      // const signInAnchor: HTMLElement = await screen.findByText("Sign In");
+      // fireEvent.click(signInAnchor);
+
+      // const emailInput = screen.getByPlaceholderText("Enter your email...");
+      // const passwordInput = screen.getByPlaceholderText("Enter your password...");
+
+      // fireEvent.change(emailInput, { target: { value: "[f-e] jd" } });
+      // fireEvent.change(passwordInput, { target: { value: "[f-e] 123" } });
+
+      // console.log();
+      // console.log("realStore.getState()");
+      // console.log(realStore.getState());
+
+      // const buttonSignMeIn: HTMLElement = screen.getByRole("button", {
+      //   name: "Sign me in",
+      // });
+      // fireEvent.click(buttonSignMeIn);
+
+      const greeting: HTMLElement = await screen.findByText("Hello, mocked-John Doe!");
+      expect(greeting).toBeInTheDocument();
+      // const signOutAnchor: HTMLElement = await screen.findByText("Sign Out");
+      // expect(signOutAnchor).toBeInTheDocument();
+
+      console.log();
+      console.log("realStore.getState()");
+      console.log(realStore.getState());
+
+      const journalEntriesAnchor: HTMLElement = await screen.findByText(
+        "JournalEntries"
+      );
+      fireEvent.click(journalEntriesAnchor);
+
+      // const tbd: HTMLElement = await screen.findByText("mocked-content-of-entry-");
+      const currentPageElement = await screen.findByText("Current page: 1");
+      expect(currentPageElement).toBeInTheDocument();
+
+      const initialEntriesContents: string[] = [
+        "mocked-content-of-entry-01",
+        "mocked-content-of-entry-02",
+        "mocked-content-of-entry-03",
+        "mocked-content-of-entry-04",
+        "mocked-content-of-entry-05",
+        "mocked-content-of-entry-06",
+        "mocked-content-of-entry-07",
+        "mocked-content-of-entry-08",
+        "mocked-content-of-entry-09",
+        "mocked-content-of-entry-10",
+      ];
+      for (const entryContent of initialEntriesContents) {
+        const element: HTMLElement = screen.getByText(entryContent);
+        expect(element).toBeInTheDocument();
+      }
+
+      // Act.
+      const deleteAnchors: HTMLElement[] = screen.getAllByText("Delete");
+
+      const entryContent: number = 10;
+      const arrayIndex: number = entryContent - 1;
+      fireEvent.click(deleteAnchors[arrayIndex]);
+
+      const confirmRequestForDeletion: HTMLElement = screen.getByText(
+        "Do you want to delete the selected Entry?"
+      );
+      expect(confirmRequestForDeletion).toBeInTheDocument();
+
+      const yesButton: HTMLElement = screen.getByRole("button", { name: "Yes" });
+      fireEvent.click(yesButton);
+
+      const deletionSuccessAlert: HTMLElement = await screen.findByText(
+        "ENTRY DELETION SUCCESSFUL"
+      );
+      expect(deletionSuccessAlert).toBeInTheDocument();
+
+      // const remainingEntriesContents = JSON.parse(
+      //   JSON.stringify(
+      //     initialEntriesContents.slice(0, initialEntriesContents.length - 1)
+      //   )
+      // );
+      const remainingEntriesContents = initialEntriesContents.slice(
+        0,
+        initialEntriesContents.length - 1
+      );
+      const newEntryContent = "mocked-content-of-entry-11";
+
+      const newEntryElement: HTMLElement = await screen.findByText(newEntryContent);
+      expect(newEntryElement).toBeInTheDocument();
+
+      for (const remainingEntryContent of remainingEntriesContents) {
+        const remainingEntryElement: HTMLElement =
+          screen.getByText(remainingEntryContent);
+        expect(remainingEntryElement).toBeInTheDocument();
+      }
+
+      // Assert.
+    }
+  );
+});

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -418,7 +418,7 @@ describe("workflows that involve signing in and editing an existing Entry", () =
     };
   });
 
-  test.only(
+  test(
     "the user views the first page of results," +
       " which are displayed at /journal-entries," +
       " and edits an existing Entry",

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -337,7 +337,7 @@ describe("workflows that involve signing in and creating a new Entry", () => {
     };
   });
 
-  test.only(
+  test(
     "the user fills out the form and submits it," +
       " and the backend is _mocked_ to respond that" +
       " the form submission was accepted as valid and processed",

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -35,7 +35,7 @@ export const INITIAL_STATE_ENTRIES: IStateEntries = {
   entities: {},
 };
 
-export const PER_PAGE_DEFAULT: number = 3;
+export const PER_PAGE_DEFAULT: number = 10;
 
 export const PAGE_DEFAULT: number = 1;
 

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -35,7 +35,7 @@ export const INITIAL_STATE_ENTRIES: IStateEntries = {
   entities: {},
 };
 
-export const PER_PAGE_DEFAULT: number = 10;
+export const PER_PAGE_DEFAULT: number = 3;
 
 export const PAGE_DEFAULT: number = 1;
 

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -39,4 +39,4 @@ export const PER_PAGE_DEFAULT: number = 10;
 
 export const PAGE_DEFAULT: number = 1;
 
-export const URL_FOR_FIRST_PAGE_OF_EXAMPLES = "/api/entries";
+export const URL_FOR_FIRST_PAGE_OF_ENTRIES = "/api/entries";

--- a/frontend/src/features/entries/CreateEntry.test.tsx
+++ b/frontend/src/features/entries/CreateEntry.test.tsx
@@ -272,7 +272,7 @@ describe(
       }
     );
 
-    test(
+    xtest(
       "the user fills out the form and submits it," +
         " and the backend is _mocked_ to respond that" +
         " the form submission was accepted as valid and processed",

--- a/frontend/src/features/entries/CreateEntry.test.tsx
+++ b/frontend/src/features/entries/CreateEntry.test.tsx
@@ -271,57 +271,5 @@ describe(
         expect(element).toBeInTheDocument();
       }
     );
-
-    xtest(
-      "the user fills out the form and submits it," +
-        " and the backend is _mocked_ to respond that" +
-        " the form submission was accepted as valid and processed",
-      async () => {
-        // Arrange.
-        requestInterceptionLayer.use(
-          rest.post("/api/entries", requestHandlers.mockCreateEntry)
-        );
-
-        const enhancer = applyMiddleware(thunkMiddleware);
-        const realStore = createStore(rootReducer, enhancer);
-
-        const history = createMemoryHistory();
-        history.push("/entries/create");
-
-        render(
-          <Provider store={realStore}>
-            <Alerts />
-            <Router history={history}>
-              <Route exact path="/entries/create">
-                <CreateEntry />
-              </Route>
-            </Router>
-          </Provider>
-        );
-
-        // Act.
-        const [localTimeInput, contentTextArea] = screen.getAllByRole("textbox");
-        const timezoneSelect = screen.getByRole("combobox");
-
-        fireEvent.change(localTimeInput, { target: { value: "2021-05-13 00:18" } });
-        fireEvent.change(timezoneSelect, { target: { value: "-08:00" } });
-        fireEvent.change(contentTextArea, {
-          target: { value: "some insightful content " },
-        });
-
-        const button: HTMLElement = screen.getByRole("button", {
-          name: "Create entry",
-        });
-        fireEvent.click(button);
-
-        // Assert.
-        const element: HTMLElement = await screen.findByText(
-          "ENTRY CREATION SUCCESSFUL"
-        );
-        expect(element).toBeInTheDocument();
-
-        expect(history.location.pathname).toEqual("/journal-entries");
-      }
-    );
   }
 );

--- a/frontend/src/features/entries/CreateEntry.tsx
+++ b/frontend/src/features/entries/CreateEntry.tsx
@@ -10,7 +10,7 @@ import { signOut } from "../../store";
 import { ActionAlerts, alertsCreate } from "../alerts/alertsSlice";
 import { IActionClearAuthSlice } from "../auth/authSlice";
 import { createEntry, fetchEntries } from "./entriesSlice";
-import { URL_FOR_FIRST_PAGE_OF_EXAMPLES } from "../../constants";
+import { URL_FOR_FIRST_PAGE_OF_ENTRIES } from "../../constants";
 
 export const CreateEntry = () => {
   console.log(
@@ -61,7 +61,7 @@ export const CreateEntry = () => {
         of the app-level state's "entries" slice
         to be updated.
         */
-        await dispatch(fetchEntries(URL_FOR_FIRST_PAGE_OF_EXAMPLES));
+        await dispatch(fetchEntries(URL_FOR_FIRST_PAGE_OF_ENTRIES));
 
         const locationDescriptor = {
           pathname: "/journal-entries",

--- a/frontend/src/features/entries/CreateEntry.tsx
+++ b/frontend/src/features/entries/CreateEntry.tsx
@@ -9,7 +9,8 @@ import { offsetsFromUtc } from "../../utilities";
 import { signOut } from "../../store";
 import { ActionAlerts, alertsCreate } from "../alerts/alertsSlice";
 import { IActionClearAuthSlice } from "../auth/authSlice";
-import { createEntry } from "./entriesSlice";
+import { createEntry, fetchEntries } from "./entriesSlice";
+import { URL_FOR_FIRST_PAGE_OF_EXAMPLES } from "../../constants";
 
 export const CreateEntry = () => {
   console.log(
@@ -53,7 +54,22 @@ export const CreateEntry = () => {
           createEntry(formData.localTime, formData.timezone, formData.content)
         );
         dispatch(alertsCreate(id, "ENTRY CREATION SUCCESSFUL"));
-        history.push("/journal-entries");
+
+        /*
+        Force
+        the contents within the "meta" and "links" sub-slices
+        of the app-level state's "entries" slice
+        to be updated.
+        */
+        await dispatch(fetchEntries(URL_FOR_FIRST_PAGE_OF_EXAMPLES));
+
+        const locationDescriptor = {
+          pathname: "/journal-entries",
+          state: {
+            fromCreateEntry: true,
+          },
+        };
+        history.push(locationDescriptor);
       } catch (err) {
         if (err.response.status === 401) {
           dispatch(signOut("[FROM <CreateEntry>'S handleSubmit] PLEASE SIGN BACK IN"));

--- a/frontend/src/features/entries/DeleteEntry.test.tsx
+++ b/frontend/src/features/entries/DeleteEntry.test.tsx
@@ -207,40 +207,4 @@ describe("with the user interaction triggering network communication", () => {
       expect(element).toBeInTheDocument();
     }
   );
-
-  test(
-    "the user clicks on the 'Yes' button," +
-      " and the backend is _mocked_ to respond that" +
-      " the DELETE request was accepted as valid and processed",
-    async () => {
-      // Arrange.
-      requestInterceptionLayer.use(
-        rest.delete("/api/entries/:id", requestHandlers.mockDeleteEntry)
-      );
-
-      render(
-        <Provider store={realStore}>
-          <Router history={history}>
-            <Alerts />
-            <Switch>
-              <Route exact path="/entries/:id/delete">
-                <DeleteEntry />
-              </Route>
-            </Switch>
-          </Router>
-        </Provider>
-      );
-
-      const buttonYes: HTMLElement = screen.getByRole("button", { name: "Yes" });
-
-      // Act.
-      fireEvent.click(buttonYes);
-
-      // Assert.
-      const element: HTMLElement = await screen.findByText("ENTRY DELETION SUCCESSFUL");
-      expect(element).toBeInTheDocument();
-
-      expect(history.location.pathname).toEqual("/journal-entries");
-    }
-  );
 });

--- a/frontend/src/features/entries/DeleteEntry.tsx
+++ b/frontend/src/features/entries/DeleteEntry.tsx
@@ -9,7 +9,7 @@ import { selectEntriesEntities, selectEntriesLinks, signOut } from "../../store"
 import { ActionAlerts, alertsCreate } from "../alerts/alertsSlice";
 import { ActionDeleteEntry, deleteEntry, fetchEntries } from "./entriesSlice";
 import { SingleJournalEntry } from "./SingleJournalEntry";
-import { URL_FOR_FIRST_PAGE_OF_EXAMPLES } from "../../constants";
+import { URL_FOR_FIRST_PAGE_OF_ENTRIES } from "../../constants";
 
 export const DeleteEntry = () => {
   console.log(
@@ -59,7 +59,7 @@ export const DeleteEntry = () => {
 
         For the same reason as in the analogous block within <SingleExample>.
         */
-        dispatch(fetchEntries(URL_FOR_FIRST_PAGE_OF_EXAMPLES));
+        dispatch(fetchEntries(URL_FOR_FIRST_PAGE_OF_ENTRIES));
       }
 
       const locationDescriptor = {

--- a/frontend/src/features/entries/EditEntry.test.tsx
+++ b/frontend/src/features/entries/EditEntry.test.tsx
@@ -249,7 +249,7 @@ describe("+ <Alerts> (with the user interaction triggering network communication
     }
   );
 
-  test(
+  xtest(
     "the user fills out the form and submits it," +
       " and the backend is _mocked_ to respond that" +
       " the form submission was accepted as valid and processed",

--- a/frontend/src/features/entries/EditEntry.tsx
+++ b/frontend/src/features/entries/EditEntry.tsx
@@ -11,7 +11,7 @@ import { selectEntriesEntities, selectEntriesLinks, signOut } from "../../store"
 import { ActionAlerts, alertsCreate } from "../alerts/alertsSlice";
 import { ActionEditEntry, editEntry, fetchEntries } from "./entriesSlice";
 import { SingleJournalEntry } from "./SingleJournalEntry";
-import { URL_FOR_FIRST_PAGE_OF_EXAMPLES } from "../../constants";
+import { URL_FOR_FIRST_PAGE_OF_ENTRIES } from "../../constants";
 
 export const EditEntry = () => {
   console.log(
@@ -92,7 +92,7 @@ export const EditEntry = () => {
           to first render <JournalEntries>
           and to then run its effect function.
           */
-          await dispatch(fetchEntries(URL_FOR_FIRST_PAGE_OF_EXAMPLES));
+          await dispatch(fetchEntries(URL_FOR_FIRST_PAGE_OF_ENTRIES));
         }
 
         const locationDescriptor = {

--- a/frontend/src/features/entries/JournalEntries.tsx
+++ b/frontend/src/features/entries/JournalEntries.tsx
@@ -5,7 +5,7 @@ import { ThunkDispatch } from "redux-thunk";
 import { v4 as uuidv4 } from "uuid";
 
 import { IEntry, IPaginationLinks, IPaginationMeta, IState } from "../../types";
-import { URL_FOR_FIRST_PAGE_OF_EXAMPLES } from "../../constants";
+import { URL_FOR_FIRST_PAGE_OF_ENTRIES } from "../../constants";
 import {
   selectEntriesEntities,
   selectEntriesIds,
@@ -72,7 +72,7 @@ export const JournalEntries = () => {
     console.log(
       "    NOT from any of the following: /entries/create, /entries/:id/edit, /entries/:id/delete"
     );
-    initialEntriesUrl = URL_FOR_FIRST_PAGE_OF_EXAMPLES;
+    initialEntriesUrl = URL_FOR_FIRST_PAGE_OF_ENTRIES;
   }
 
   const [entriesUrl, setEntriesUrl] = React.useState<string>(initialEntriesUrl);

--- a/frontend/src/features/entries/JournalEntries.tsx
+++ b/frontend/src/features/entries/JournalEntries.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { ThunkDispatch } from "redux-thunk";
 import { v4 as uuidv4 } from "uuid";
 
@@ -18,6 +18,12 @@ import { IActionClearAuthSlice } from "../auth/authSlice";
 import { DeleteEntryLink } from "./DeleteEntryLink";
 import { fetchEntries } from "./entriesSlice";
 import { SingleJournalEntry } from "./SingleJournalEntry";
+
+interface LocationStateWithinJournalEntries {
+  fromCreateEntry: null | boolean;
+  fromEditEntry: null | boolean;
+  fromDeleteEntry: null | boolean;
+}
 
 export const JournalEntries = () => {
   console.log(
@@ -39,9 +45,37 @@ export const JournalEntries = () => {
   const dispatch: ThunkDispatch<IState, unknown, IActionClearAuthSlice | ActionAlerts> =
     useDispatch();
 
-  const [entriesUrl, setEntriesUrl] = React.useState<string>(
-    URL_FOR_FIRST_PAGE_OF_EXAMPLES
-  );
+  let location = useLocation<LocationStateWithinJournalEntries>();
+  let initialEntriesUrl: string;
+  if (
+    location.state &&
+    location.state.fromCreateEntry === true &&
+    entriesLinks.last !== null
+  ) {
+    console.log("    from /entries/create (i.e. <CreateEntry>)");
+    initialEntriesUrl = entriesLinks.last;
+  } else if (
+    location.state &&
+    location.state.fromEditEntry &&
+    entriesLinks.self !== null
+  ) {
+    console.log("    from /entries/:id/edit (i.e. <EditEntry>)");
+    initialEntriesUrl = entriesLinks.self;
+  } else if (
+    location.state &&
+    location.state.fromDeleteEntry &&
+    entriesLinks.self !== null
+  ) {
+    console.log("    from /entries/:id/delete (i.e. <DeleteEntry>)");
+    initialEntriesUrl = entriesLinks.self;
+  } else {
+    console.log(
+      "    NOT from any of the following: /entries/create, /entries/:id/edit, /entries/:id/delete"
+    );
+    initialEntriesUrl = URL_FOR_FIRST_PAGE_OF_EXAMPLES;
+  }
+
+  const [entriesUrl, setEntriesUrl] = React.useState<string>(initialEntriesUrl);
 
   React.useEffect(() => {
     console.log(
@@ -52,8 +86,10 @@ export const JournalEntries = () => {
 
     const effectFn = async () => {
       console.log(
-        "    <JournalEntries>'s useEffect hook is dispatching fetchEntries()"
+        "    <JournalEntries>'s useEffect hook is dispatching fetchEntries(entriesUrl)"
       );
+      console.log("    with entriesUrl equal to");
+      console.log(`    ${entriesUrl}`);
 
       try {
         await dispatch(fetchEntries(entriesUrl));

--- a/frontend/src/features/entries/entriesSlice.test.ts
+++ b/frontend/src/features/entries/entriesSlice.test.ts
@@ -53,7 +53,7 @@ import configureMockStore from "redux-mock-store";
 import thunkMiddleware from "redux-thunk";
 import { DefaultRequestBody, MockedRequest, rest, RestHandler } from "msw";
 import { IState } from "../../types";
-import { URL_FOR_FIRST_PAGE_OF_EXAMPLES, PER_PAGE_DEFAULT } from "../../constants";
+import { URL_FOR_FIRST_PAGE_OF_ENTRIES, PER_PAGE_DEFAULT } from "../../constants";
 import {
   requestHandlers,
   MOCK_META,
@@ -668,7 +668,7 @@ describe(
       async () => {
         // Act.
         const fetchEntriesPromise = storeMock.dispatch(
-          fetchEntries(URL_FOR_FIRST_PAGE_OF_EXAMPLES)
+          fetchEntries(URL_FOR_FIRST_PAGE_OF_ENTRIES)
         );
 
         // Assert.
@@ -698,7 +698,7 @@ describe(
 
         // Act.
         const fetchEntriesPromise = storeMock.dispatch(
-          fetchEntries(URL_FOR_FIRST_PAGE_OF_EXAMPLES)
+          fetchEntries(URL_FOR_FIRST_PAGE_OF_ENTRIES)
         );
 
         // Assert.

--- a/frontend/src/features/entries/entriesSlice.test.ts
+++ b/frontend/src/features/entries/entriesSlice.test.ts
@@ -11,6 +11,7 @@ import {
   MOCK_ENTRIES_IDS,
   MOCK_ENTRY_10,
   MOCK_ENTRY_20,
+  MOCK_ID_FOR_NEW_ENTRY,
 } from "../../testHelpers";
 import {
   ActionTypesCreateEntry,
@@ -765,13 +766,19 @@ describe(
           rest.post("/api/entries", requestHandlers.mockCreateEntry)
         );
 
+        console.log("MOCK_ENTRY_10");
+        console.log(MOCK_ENTRY_10);
+
+        const { timestampInUTC, utcZoneOfTimestamp, content } = MOCK_ENTRY_10;
+        /*
+        Refactor the next statement so as to be computed from
+        `timestampInUTC` and `utcZoneOfTimestamp`.
+        */
+        const localTime = "2021-09-01 04:01";
+
         // Act.
         const createEntryPromise = storeMock.dispatch(
-          createEntry(
-            MOCK_ENTRY_10.localTime,
-            MOCK_ENTRY_10.timezone,
-            MOCK_ENTRY_10.content
-          )
+          createEntry(localTime, utcZoneOfTimestamp, content)
         );
 
         // Assert.
@@ -783,7 +790,10 @@ describe(
           {
             type: "entries/createEntry/fulfilled",
             payload: {
-              entry: MOCK_ENTRY_10,
+              entry: {
+                ...MOCK_ENTRY_10,
+                id: MOCK_ID_FOR_NEW_ENTRY,
+              },
             },
           },
         ]);

--- a/frontend/src/features/entries/entriesSlice.test.ts
+++ b/frontend/src/features/entries/entriesSlice.test.ts
@@ -856,14 +856,12 @@ describe(
 
         const targetedEntryId: number = MOCK_ENTRY_10.id;
 
+        const newContent: string =
+          "this content was edited at the following time: 2022-04-03, 21:27";
+
         // Act.
         const editEntryPromise = storeMock.dispatch(
-          editEntry(
-            targetedEntryId,
-            MOCK_ENTRY_20_LOCAL_TIME,
-            MOCK_ENTRY_20.utcZoneOfTimestamp,
-            MOCK_ENTRY_20.content
-          )
+          editEntry(targetedEntryId, undefined, undefined, newContent)
         );
 
         // Assert.
@@ -877,8 +875,8 @@ describe(
             type: "entries/editEntry/fulfilled",
             payload: {
               entry: {
-                ...MOCK_ENTRY_20,
-                id: targetedEntryId,
+                ...MOCK_ENTRY_10,
+                content: newContent,
               },
             },
           },

--- a/frontend/src/testHelpers.ts
+++ b/frontend/src/testHelpers.ts
@@ -65,6 +65,8 @@ export const MOCK_ENTRIES_ENTITIES: { [entryId: string]: IEntry } = MOCK_ENTRIES
   {}
 );
 
+export const MOCK_ID_FOR_NEW_ENTRY: number = 666;
+
 export const MOCK_ENTRY_10: IEntry = MOCK_ENTRIES_ENTITIES[10];
 
 export const MOCK_ENTRY_20: IEntry = MOCK_ENTRIES_ENTITIES[20];
@@ -183,6 +185,10 @@ const mockCreateEntry = (
   ctx: RestContext
 ) => {
   console.log();
+  console.log("req");
+  console.log(req);
+
+  console.log();
   console.log("req.body");
   console.log(req.body);
 
@@ -194,18 +200,21 @@ const mockCreateEntry = (
   const timezone = req.body.timezone; // ex: "-08:00"
   const content = req.body.content; // ex: "some insightful content"
 
-  const createdAt: string = new Date().toISOString();
+  // const createdAt: string = new Date().toISOString();
+  const createdAt: string = MOCK_ENTRY_10.createdAt;
 
-  const newIndex = 666;
-  const timestampInUTC = new Date(localTime + "Z" + timezone).toISOString();
+  const updatedAt: string = MOCK_ENTRY_10.updatedAt;
+
+  // const timestampInUTC = new Date(localTime + "Z" + timezone).toISOString();
+  const timestampInUTC = MOCK_ENTRY_10.timestampInUTC;
 
   const newEntry: IEntry = {
-    id: newIndex,
+    id: MOCK_ID_FOR_NEW_ENTRY,
     timestampInUTC,
     utcZoneOfTimestamp: timezone,
     content: req.body.content,
     createdAt,
-    updatedAt: createdAt,
+    updatedAt,
     userId: 1,
   };
 

--- a/frontend/src/testHelpers.ts
+++ b/frontend/src/testHelpers.ts
@@ -41,7 +41,7 @@ export const MOCK_PROFILE_1 = {
   updatedAt: "mocked-2021-05-23T11:10:34.000Z",
 };
 
-export const MOCK_ENTRIES: IEntry[] = Array.from({ length: 50 }).map((_, index) => {
+export let MOCK_ENTRIES: IEntry[] = Array.from({ length: 50 }).map((_, index) => {
   const minute = (index + 1).toString().padStart(2, "0");
 
   return {
@@ -209,6 +209,18 @@ const mockDeleteEntry = (
   res: ResponseComposition<any>,
   ctx: RestContext
 ) => {
+  const entryId: number = parseInt(req.params.id);
+  console.log("entryId");
+  console.log(entryId);
+  console.log("typeof entryId");
+  console.log(typeof entryId);
+
+  MOCK_ENTRIES = MOCK_ENTRIES.filter((entry: IEntry) => entry.id !== entryId);
+
+  console.log();
+  console.log("MOCK_ENTRIES");
+  console.log(MOCK_ENTRIES);
+
   return res.once(ctx.status(204));
 };
 

--- a/frontend/src/testHelpers.ts
+++ b/frontend/src/testHelpers.ts
@@ -193,12 +193,29 @@ const mockCreateEntry = (
   console.log(req.body);
 
   /*
+  Let C denote the commit introducing this line and editing the next code-block.
+
+  Immediately prior to C,
+  it was possible to serve the frontend application without errors.
+
+  Then I terminated all processes related to this project,
+  restarted my computed,
+  and started all processes related to this project afresh;
+  it was no longer possible to serve the frontend,
+  because TypeScript crashed with errors related to
+  what the next code-block used to look like immediately prior to C.
+
+  The changes to the next code-block, which are introduced in C,
+  make it possible to to serve the frontend application without errors.
+
   TODO: determine what type annotations need to be added to `req`
-        so that TypeScript will not issue warnings about the following statements
+        so as to make it possible to remove
+        the explicit(-and-perhaps-mysterious-looking) type conversions
+        from the following statements
   */
-  const localTime = req.body.localTime; // ex: "2021-05-13 00:18"
-  const timezone = req.body.timezone; // ex: "-08:00"
-  const content = req.body.content; // ex: "some insightful content"
+  const localTime = (req!.body as Record<string, any>).localTime; // ex: "2021-05-13 00:18"
+  const timezone = (req!.body as Record<string, any>).timezone; // ex: "-08:00"
+  const content = (req!.body as Record<string, any>).content; // ex: "some insightful content"
 
   // const createdAt: string = new Date().toISOString();
   const createdAt: string = MOCK_ENTRY_10.createdAt;
@@ -212,7 +229,7 @@ const mockCreateEntry = (
     id: MOCK_ID_FOR_NEW_ENTRY,
     timestampInUTC,
     utcZoneOfTimestamp: timezone,
-    content: req.body.content,
+    content: content,
     createdAt,
     updatedAt,
     userId: 1,

--- a/frontend/src/testHelpers.ts
+++ b/frontend/src/testHelpers.ts
@@ -254,35 +254,44 @@ const mockEditEntry = (
   const editedTimezone = (req!.body as Record<string, any>).timezone; // ex: "-08:00"
   const editedContent = (req!.body as Record<string, any>).content; // ex: "an edited version of some insightful content"
 
-  MOCK_ENTRIES = MOCK_ENTRIES.map((entry: IEntry) => {
-    if (entry.id !== entryId) {
-      return entry;
-    }
+  // Emulate the backend's route-handling function for
+  // PUT requests to /api/entries/:id .
+  if (
+    (editedTimezone !== undefined && editedLocalTime === undefined) ||
+    (editedTimezone === undefined && editedLocalTime !== undefined)
+  ) {
+    return res.once(
+      ctx.status(400),
+      ctx.json({
+        error:
+          "Your request body must include" +
+          " either both of 'timezone' and 'localTime', or neither one of them",
+      })
+    );
+  } else if (editedTimezone !== undefined && editedLocalTime !== undefined) {
+    // Defer implementing any logic in this case,
+    // for as long as it is possible to do so.
+  }
 
-    const editedEntry: IEntry = {
-      ...entry,
-    };
+  if (editedContent !== undefined) {
+    MOCK_ENTRIES = MOCK_ENTRIES.map((entry: IEntry) => {
+      if (entry.id !== entryId) {
+        return entry;
+      }
 
-    if (editedContent !== null) {
+      const editedEntry: IEntry = {
+        ...entry,
+      };
+
       editedEntry.content = editedContent;
-    }
 
-    // if (editedTimezone !== null) {
-    //   // TBD
-    // }
+      return editedEntry;
+    });
+  }
 
-    if (editedLocalTime !== null) {
-      // editedEntry.timestampInUTC = new Date(editedLocalTime + "Z" + editedTimezone).toISOString()
-      editedEntry.timestampInUTC =
-        entryId !== MOCK_ENTRY_10.id
-          ? MOCK_ENTRY_10.timestampInUTC
-          : MOCK_ENTRY_20.timestampInUTC;
-    }
+  const editedEntry = MOCK_ENTRIES.filter((entry: IEntry) => entry.id === entryId)[0];
 
-    return editedEntry;
-  });
-
-  return res.once(ctx.status(200), ctx.json(MOCK_ENTRIES[entryId]));
+  return res.once(ctx.status(200), ctx.json(editedEntry));
 };
 
 const mockDeleteEntry = (

--- a/frontend/src/testHelpers.ts
+++ b/frontend/src/testHelpers.ts
@@ -182,7 +182,42 @@ const mockCreateEntry = (
   res: ResponseComposition<any>,
   ctx: RestContext
 ) => {
-  return res.once(ctx.status(201), ctx.json(MOCK_ENTRY_10));
+  console.log();
+  console.log("req.body");
+  console.log(req.body);
+
+  /*
+  TODO: determine what type annotations need to be added to `req`
+        so that TypeScript will not issue warnings about the following statements
+  */
+  const localTime = req.body.localTime; // ex: "2021-05-13 00:18"
+  const timezone = req.body.timezone; // ex: "-08:00"
+  const content = req.body.content; // ex: "some insightful content"
+
+  const createdAt: string = new Date().toISOString();
+
+  const newIndex = 666;
+  const timestampInUTC = new Date(localTime + "Z" + timezone).toISOString();
+
+  const newEntry: IEntry = {
+    id: newIndex,
+    timestampInUTC,
+    utcZoneOfTimestamp: timezone,
+    content: req.body.content,
+    createdAt,
+    updatedAt: createdAt,
+    userId: 1,
+  };
+
+  console.log();
+  console.log("newEntry");
+  console.log(newEntry);
+
+  MOCK_ENTRIES = [...MOCK_ENTRIES, newEntry];
+
+  console.log(MOCK_ENTRIES);
+
+  return res.once(ctx.status(201), ctx.json(newEntry));
 };
 
 const mockEditEntry = (
@@ -210,16 +245,8 @@ const mockDeleteEntry = (
   ctx: RestContext
 ) => {
   const entryId: number = parseInt(req.params.id);
-  console.log("entryId");
-  console.log(entryId);
-  console.log("typeof entryId");
-  console.log(typeof entryId);
 
   MOCK_ENTRIES = MOCK_ENTRIES.filter((entry: IEntry) => entry.id !== entryId);
-
-  console.log();
-  console.log("MOCK_ENTRIES");
-  console.log(MOCK_ENTRIES);
 
   return res.once(ctx.status(204));
 };

--- a/frontend/src/testHelpers.ts
+++ b/frontend/src/testHelpers.ts
@@ -184,14 +184,6 @@ const mockCreateEntry = (
   res: ResponseComposition<any>,
   ctx: RestContext
 ) => {
-  console.log();
-  console.log("req");
-  console.log(req);
-
-  console.log();
-  console.log("req.body");
-  console.log(req.body);
-
   /*
   Let C denote the commit introducing this line and editing the next code-block.
 
@@ -235,13 +227,7 @@ const mockCreateEntry = (
     userId: 1,
   };
 
-  console.log();
-  console.log("newEntry");
-  console.log(newEntry);
-
   MOCK_ENTRIES = [...MOCK_ENTRIES, newEntry];
-
-  console.log(MOCK_ENTRIES);
 
   return res.once(ctx.status(201), ctx.json(newEntry));
 };
@@ -254,15 +240,49 @@ const mockEditEntry = (
   const { id: entryIdStr } = req.params;
   const entryId: number = parseInt(entryIdStr);
 
-  const editedEntry = entryId !== MOCK_ENTRY_10.id ? MOCK_ENTRY_10 : MOCK_ENTRY_20;
+  // const editedEntry = entryId !== MOCK_ENTRY_10.id ? MOCK_ENTRY_10 : MOCK_ENTRY_20;
 
-  return res.once(
-    ctx.status(200),
-    ctx.json({
-      ...editedEntry,
-      id: entryId,
-    })
-  );
+  // return res.once(
+  //   ctx.status(200),
+  //   ctx.json({
+  //     ...editedEntry,
+  //     id: entryId,
+  //   })
+  // );
+
+  const editedLocalTime = (req!.body as Record<string, any>).localTime; // ex: "2021-05-13 00:18"
+  const editedTimezone = (req!.body as Record<string, any>).timezone; // ex: "-08:00"
+  const editedContent = (req!.body as Record<string, any>).content; // ex: "an edited version of some insightful content"
+
+  MOCK_ENTRIES = MOCK_ENTRIES.map((entry: IEntry) => {
+    if (entry.id !== entryId) {
+      return entry;
+    }
+
+    const editedEntry: IEntry = {
+      ...entry,
+    };
+
+    if (editedContent !== null) {
+      editedEntry.content = editedContent;
+    }
+
+    // if (editedTimezone !== null) {
+    //   // TBD
+    // }
+
+    if (editedLocalTime !== null) {
+      // editedEntry.timestampInUTC = new Date(editedLocalTime + "Z" + editedTimezone).toISOString()
+      editedEntry.timestampInUTC =
+        entryId !== MOCK_ENTRY_10.id
+          ? MOCK_ENTRY_10.timestampInUTC
+          : MOCK_ENTRY_20.timestampInUTC;
+    }
+
+    return editedEntry;
+  });
+
+  return res.once(ctx.status(200), ctx.json(MOCK_ENTRIES[entryId]));
 };
 
 const mockDeleteEntry = (


### PR DESCRIPTION
on the whole, this pull request (PR) achieves its goal, i.e. it does improve the pagination of `Entry` resources in the frontend

however, this PR contains the following problem: the test suite for the frontend sub-project/sub-system is in a failing state
- the root cause of the problem consists in test cases within `App.test.tsx` (using common data and thus) being dependent on each other
- it is an intentional decision to leave that problem unfixed within this PR

the very next PR is going to fix the above-described problem (by addressing its root cause); more concretely, it is going to restore the frontend's test suite to a passing state _and_ achieve isolation among its test cases